### PR TITLE
fix: settings and langfuse errors

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-ocr"
-version = "0.1.0"
+version = "0.3.3"
 description = "Langchain OCR API"
 authors = ["Andreas Klos"]
 packages = [{ include = "langchain_ocr", from = "src" }]

--- a/langchain_ocr_lib/pyproject.toml
+++ b/langchain_ocr_lib/pyproject.toml
@@ -7,7 +7,7 @@ langchain-ocr = "langchain_ocr_lib.main:main"
 
 [tool.poetry]
 name = "langchain-ocr-lib"
-version = "0.3.2"
+version = "0.3.3"
 description = "Modular, vision-LLM-powered chain to convert image and PDF documents into clean Markdown."
 authors = ["Andreas Klos <aklos@outlook.de>"]
 readme = "README.md"

--- a/langchain_ocr_lib/src/langchain_ocr_lib/di_config.py
+++ b/langchain_ocr_lib/src/langchain_ocr_lib/di_config.py
@@ -48,22 +48,25 @@ def lib_di_config(binder: Binder):
     langfuse_settings = LangfuseSettings()
     llm_class_type_settings = LlmClassTypeSettings()
     language_settings = LanguageSettings()
-
+    model_name = ""
     if llm_class_type_settings.llm_type == "ollama":
         settings = OllamaSettings()
+        model_name = settings.model
         partial_llm_provider = partial(llm_provider,settings, ChatOllama)
     elif llm_class_type_settings.llm_type == "openai":
         settings = OpenAISettings()
+        model_name = settings.model_name
         partial_llm_provider = partial(llm_provider,settings, ChatOpenAI)
     elif llm_class_type_settings.llm_type == "vllm":
         settings = VllmSettings()
+        model_name = settings.model_name
         partial_llm_provider = partial(llm_provider,settings, ChatOpenAI)
     else:
         raise NotImplementedError("Configured LLM is not implemented")
     
     binder.bind_to_provider(LargeLanguageModelKey, partial_llm_provider)
 
-    prompt = ocr_prompt_template_builder(language=language_settings.language, model_name=settings.model)
+    prompt = ocr_prompt_template_builder(language=language_settings.language, model_name=model_name)
 
     binder.bind(
         LangfuseClientKey,

--- a/langchain_ocr_lib/src/langchain_ocr_lib/impl/langfuse_manager/langfuse_manager.py
+++ b/langchain_ocr_lib/src/langchain_ocr_lib/impl/langfuse_manager/langfuse_manager.py
@@ -58,9 +58,10 @@ class LangfuseManager:
         Exception
             If an error occurs while retrieving the prompt template from Langfuse.
         """
+        langfuse_prompt = None
         if not self._enabled:
             logger.info("Langfuse is not enabled. Using fallback prompt.")
-            return None
+            return langfuse_prompt
         try:
             langfuse_prompt = self._langfuse.get_prompt(base_prompt_name)
         except NotFoundError:

--- a/langchain_ocr_lib/src/langchain_ocr_lib/impl/llms/llm_factory.py
+++ b/langchain_ocr_lib/src/langchain_ocr_lib/impl/llms/llm_factory.py
@@ -43,6 +43,7 @@ def get_configurable_fields_from(settings: BaseSettings) -> dict[str, Configurab
         settings_of_interest = settings.model_fields[field_name]
         if settings_of_interest.title is not None:
             _fields[field_name] = ConfigurableField(id=field_name, name=settings_of_interest.title)
+    
     return _fields
 
 

--- a/langchain_ocr_lib/src/langchain_ocr_lib/impl/settings/openai_chat_settings.py
+++ b/langchain_ocr_lib/src/langchain_ocr_lib/impl/settings/openai_chat_settings.py
@@ -10,7 +10,7 @@ class OpenAISettings(BaseSettings):
 
     Attributes
     ----------
-    model : str
+    model_name : str
         The model identifier.
     api_key : str
         The API key for authentication.
@@ -28,7 +28,12 @@ class OpenAISettings(BaseSettings):
         env_prefix = "OPENAI_"
         case_sensitive = False
 
-    model: str = Field(default="gpt-4o-mini-search-preview-2025-03-11", description="The model identifier", title="LLM Model")
+    model_name: str = Field(
+        default="gpt-4o-mini-search-preview-2025-03-11",
+        env="MODEL",
+        description="The model identifier",
+        title="LLM Model",
+    )
     api_key: str = Field(default="", description="The API key for authentication")
     top_p: float = Field(default=1.0, description="Total probability mass of tokens to consider at each step", title="Top P")
     temperature: float = Field(default=0, description="What sampling temperature to use", title="Temperature")

--- a/langchain_ocr_lib/src/langchain_ocr_lib/impl/settings/vllm_chat_settings.py
+++ b/langchain_ocr_lib/src/langchain_ocr_lib/impl/settings/vllm_chat_settings.py
@@ -10,7 +10,7 @@ class VllmSettings(BaseSettings):
 
     Attributes
     ----------
-    model : str
+    model_name : str
         The model identifier.
     api_key : str
         The API key for authentication.
@@ -28,7 +28,12 @@ class VllmSettings(BaseSettings):
         env_prefix = "VLLM_"
         case_sensitive = False
 
-    model: str = Field(default="", description="The model identifier", title="LLM Model")
+    model_name: str = Field(
+        default="",
+        env="MODEL",
+        description="The model identifier",
+        title="LLM Model",
+    )
     api_key: str = Field(default="", description="The API key for authentication")
     top_p: float = Field(default=1.0, description="Total probability mass of tokens to consider at each step", title="Top P")
     temperature: float = Field(default=0, description="What sampling temperature to use", title="Temperature")


### PR DESCRIPTION
change model of openai and vllm settings to model_name
initialize variable in langfuse_manager. if langfuse not available, no error is anymore caused.